### PR TITLE
Now loads full list of current users for a new connection.

### DIFF
--- a/src/Collab.js
+++ b/src/Collab.js
@@ -118,7 +118,7 @@ class Collab extends Component {
         });
         if (this.state.componentSocketId === 0) {
             this.setState({
-                collaborators: [{socketId, userName}],
+                collaborators: connections.currentConnections,
                 componentSocketId: socketId,
             });
             this.addNotificationAlert("You joined the page! You are known as: " + userName);


### PR DESCRIPTION
Before, a new user connecting would only receive a list of users that contained themselves. Now, they see every user connected to the room.